### PR TITLE
Fixed bug in 2d convolution algo on GPU

### DIFF
--- a/convolution2d_testcases.py
+++ b/convolution2d_testcases.py
@@ -51,8 +51,8 @@ print('Total memory on GPU = {0:.2f} MB'.format(GPU_memorySize));
 thrdPerBlockx = 16;
 thrdPerBlocky = 16;
 thrdPerBlock = (thrdPerBlocky,thrdPerBlockx);
-blkPerGridx = int(cp.ceil(outputImage.shape[1])/thrdPerBlockx);
-blkPerGridy = int(cp.ceil(outputImage.shape[0])/thrdPerBlocky);
+blkPerGridx = int(cp.ceil(inputImage_gpu_ext.shape[1]/thrdPerBlockx));
+blkPerGridy = int(cp.ceil(inputImage_gpu_ext.shape[0]/thrdPerBlocky));
 blkPerGrid = (blkPerGridy, blkPerGridx)
 
 

--- a/numbaCudaKernels.py
+++ b/numbaCudaKernels.py
@@ -39,10 +39,13 @@ def conv_2d(inputImageExtnd, pointSpreadFn, outputImage, InputLenX, InputLenY, p
     convSum = cp.float32(0)
     for x in range(-psfOneSideLenX,psfOneSideLenX+1):
         for y in range(-psfOneSideLenY,psfOneSideLenY+1):
-            convSum += inputImageExtnd[thrdIDy+y,thrdIDx+x]*pointSpreadFn[2*psfOneSideLenY-y,2*psfOneSideLenX-x];
+            convSum += inputImageExtnd[thrdIDy+y,thrdIDx+x]*pointSpreadFn[psfOneSideLenY-y,psfOneSideLenX-x];
+            # if (thrdIDx == psfOneSideLenX + InputLenX + psfLenX -2) and (thrdIDy == psfOneSideLenY + InputLenY + psfLenY -2):
+            #     print('x:',x,'y:',y,'imagVal:',inputImageExtnd[thrdIDy+y,thrdIDx+x],'psfval:',pointSpreadFn[2*psfOneSideLenY-y,2*psfOneSideLenX-x])
    
-    
-    outputImage[thrdIDy,thrdIDx] = convSum;
+    # if (thrdIDx == psfOneSideLenX + InputLenX + psfLenX -2) and (thrdIDy == psfOneSideLenY + InputLenY + psfLenY -2):
+    #     print('conSum:',convSum)
+    outputImage[thrdIDy-psfOneSideLenY,thrdIDx-psfOneSideLenX] = convSum;
     
     
     


### PR DESCRIPTION
In this commit, I have fixed a major bug in the way the 2d convolution
was being computed on the GPU using the numba cuda kernel. The following
are the changes made which fixed the bug.
1. BlocksperGrid varaible was not being computed correctly. The ceil
operation should be applied after division with the threadsPerBlock but
it was applied before the division.

2. The point spread function (2d impulse response) was not being
accessed correctly and hence it had some zero values. Because of this,
the convolution sum was not correct.

3. The output image was not indexed correctly with respect to the
thread indices

Signed-off-by: Sai Gunaranjan Pelluri <saigunaranjanpelluri@gmail.com>