### PR TITLE
Compute 2D convolution for any 3D image

### DIFF
--- a/convolution2d_testcases.py
+++ b/convolution2d_testcases.py
@@ -19,11 +19,13 @@ from scipy import signal
 plt.close('all')
 
 imageFolderPath = 'test_images\\'
-imageName = imageFolderPath + 'barbara.png' # 'CheckboardWithNoise.jpg' 
+imageName = imageFolderPath + '1Orig.jpg' #'barbara.png' # 'CheckboardWithNoise.jpg' 
 inputImage = imageio.imread(imageName)
+
 
 if len(inputImage.shape)==2:
     inputImage = inputImage[:,:,None]
+inputImageDtype = type(inputImage[0,0,0])
 inputImageLenX = inputImage.shape[1]
 inputImageLenY = inputImage.shape[0]
 psfLenX = 5 # should always be an odd number
@@ -64,8 +66,9 @@ for ele in range(inputImage.shape[2]):
 
 
 t4 = time();
-
-outputImage_cpu = signal.convolve2d(inputImage.squeeze(),pointSpreadFn);
+outputImage_cpu = np.zeros((outputImage.shape[0],outputImage.shape[1],inputImage.shape[2]),dtype=np.float32)
+for ele in range(inputImage.shape[2]):
+    outputImage_cpu[:,:,ele] = signal.convolve2d(inputImage[:,:,ele],pointSpreadFn);
 
 t5 = time();
 
@@ -74,16 +77,26 @@ print('GPU compute + Fetch time = {0:.0f} ms'.format((t4-t3)*1000));
 print('Total GPU transfer + compute + fetch time = {0:.0f} ms'.format((t4-t1)*1000))
 print('CPU compute time = {0:.0f} ms'.format((t5-t4)*1000))
 
+
+"""Normalize to 255 (to convert to 8 bit int in next step"""
+outputImage_cpu = (outputImage_cpu/np.amax(outputImage_cpu,axis=(0,1))[None,None,:])*255
+outputImage_ker = (outputImage_ker/np.amax(outputImage_ker,axis=(0,1))[None,None,:])*255
+
+""" convert to unsigned 8 bit int after havng normalized all the values to 2^8 -1"""
+outputImage_cpu_uint8 = np.uint8(outputImage_cpu).squeeze()
+outputImage_ker_uint8 = np.uint8(outputImage_ker).squeeze()
+
+
 plt.figure(1,figsize=(20,10));
 plt.subplot(131);
 plt.title('original')
 plt.imshow(inputImage.squeeze(),cmap='gray')
 plt.subplot(132);
-plt.title('CPU convolved')
-plt.imshow(outputImage_cpu.squeeze(),cmap='gray')
+plt.title('CPU convolved. Time taken is ' + str(round((t5-t4)*1000)) + ' ms')
+plt.imshow(outputImage_cpu_uint8,cmap='gray')
 plt.subplot(133);
-plt.title('GPU convolved')
-plt.imshow(outputImage_ker.squeeze(),cmap='gray')
+plt.title('GPU convolved. Time taken is ' + str(round((t4-t1)*1000)) + ' ms')
+plt.imshow(outputImage_ker_uint8,cmap='gray')
 
 
 


### PR DESCRIPTION
In this commit, I have solved the previous issue where I was able to
perform a 2D convolution only for a 2D image. Now, with these changes,
the convolution can be generalized to any 3D image which has the 3
components of Red, Green, Blue (RGB). Following are the changes
introduced.

1. Performing 2D convolution to each of the 2D slices of the 3D image
i.e. 2D convolution with each of the R image, G image, B image
separately.

2. Previously, I was not able to generalise to a 3D image. Now I have
solved it. This is the explanation.
Generally, the input images are uint8 i.e each pixel value in the image
is represented by a unsigned 8 bit integer value and hence it will have
integer values from 0 to 2^5 -1 i.e. 255. But, our convolution operation
might result in values which are larger than 255. Hence after our
convolution operation, we need to convert the image from float32 to
uint8. For this, we first normalize, the every slice of the output 3D
image with the corresponding maximum value. Now each slice will have
values from 0 to 1. Now, we multiply with 255 and hence each slice has
values from 0 to 255. After this, we convert to uint8. Now we can plot
and compare with respect to the nput image.

3. Also added the time taken by the CPU and GPU in the results plot.

Signed-off-by: Sai Gunaranjan Pelluri <saigunaranjanpelluri@gmail.com>